### PR TITLE
Add_a_gcp_sumologic_module_for_cloudlogging

### DIFF
--- a/gcp/cloudlogging/README.md
+++ b/gcp/cloudlogging/README.md
@@ -1,0 +1,63 @@
+# SumoLogic-GCP-Logging
+
+
+This module is used to create GCP and Sumo Logic resources to collect logs from the [Cloud Logging] service in GCP.
+Features include:
+- Create a Sumologic source and a collector
+- Create a PubSub Topic and a Subscription
+- Create a Cloud Logging Sink
+- Assign the pubsub.publisher role to the Cloud Logging service account
+
+For examples please check the [example] folder.
+
+<!-- Links -->
+[Cloud Logging]:https://cloud.google.com/logging
+[example]:(example)
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
+| <a name="requirement_sumologic"></a> [sumologic](#requirement\_sumologic) | >= 2.11 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.0 |
+| <a name="provider_sumologic"></a> [sumologic](#provider\_sumologic) | >= 2.11 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_logging_project_sink.sumologic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_project_iam_binding.sumologic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
+| [google_pubsub_subscription.sumologic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_topic.sumologic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [sumologic_collector.this](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/collector) | resource |
+| [sumologic_gcp_source.this](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/gcp_source) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_gcp_project"></a> [gcp\_project](#input\_gcp\_project) | GCP project ID. | `string` | n/a | yes |
+| <a name="input_logging_sink_filter"></a> [logging\_sink\_filter](#input\_logging\_sink\_filter) | Logging filter for the GCP sink. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Names that will be assigned to resources. | `string` | n/a | yes |
+| <a name="input_sumologic_category"></a> [sumologic\_category](#input\_sumologic\_category) | The category description for the collector/source. | `string` | `"gcp"` | no |
+| <a name="input_sumologic_collector_fields"></a> [sumologic\_collector\_fields](#input\_sumologic\_collector\_fields) | A Map containing key/value pairs. | `map(any)` | `null` | no |
+| <a name="input_sumologic_collector_name"></a> [sumologic\_collector\_name](#input\_sumologic\_collector\_name) | Name for the collector. | `string` | `null` | no |
+| <a name="input_sumologic_collector_timezone"></a> [sumologic\_collector\_timezone](#input\_sumologic\_collector\_timezone) | The time zone to use for this collector. | `string` | `null` | no |
+| <a name="input_sumologic_description"></a> [sumologic\_description](#input\_sumologic\_description) | The description of the created resources collector/source. | `string` | `null` | no |
+| <a name="input_sumologic_source_name"></a> [sumologic\_source\_name](#input\_sumologic\_source\_name) | Name for the GCP source. | `string` | `null` | no |
+
+## Outputs
+
+No outputs.

--- a/gcp/cloudlogging/example/simple/main.tf
+++ b/gcp/cloudlogging/example/simple/main.tf
@@ -1,0 +1,12 @@
+locals {
+  project = "some-project-name"
+  name    = "sumologic"
+}
+
+module "sumologic" {
+  source = "../.."
+
+  name        = local.name
+  gcp_project = local.project
+
+}

--- a/gcp/cloudlogging/gcp.tf
+++ b/gcp/cloudlogging/gcp.tf
@@ -1,0 +1,38 @@
+resource "google_project_iam_binding" "sumologic" {
+  project = var.gcp_project
+
+  role = "roles/pubsub.publisher"
+
+  members = [
+    "serviceAccount:cloud-logs@system.gserviceaccount.com"
+  ]
+}
+
+resource "google_logging_project_sink" "sumologic" {
+  project = var.gcp_project
+
+  name = var.name
+
+  destination = "pubsub.googleapis.com/${google_pubsub_topic.sumologic.id}"
+
+  filter = var.logging_sink_filter
+}
+
+resource "google_pubsub_subscription" "sumologic" {
+  project = var.gcp_project
+
+  name  = var.name
+  topic = google_pubsub_topic.sumologic.name
+
+  ack_deadline_seconds = 20
+
+  push_config {
+    push_endpoint = sumologic_gcp_source.this.url
+  }
+}
+
+resource "google_pubsub_topic" "sumologic" {
+  project = var.gcp_project
+
+  name = var.name
+}

--- a/gcp/cloudlogging/sumologic.tf
+++ b/gcp/cloudlogging/sumologic.tf
@@ -1,0 +1,19 @@
+locals {
+  sumologic_collector_name = var.sumologic_collector_name == null ? var.name : var.sumologic_collector_name
+  sumologic_source_name    = var.sumologic_source_name == null ? var.name : var.sumologic_source_name
+}
+resource "sumologic_collector" "this" {
+  name        = local.sumologic_collector_name
+  description = var.sumologic_description
+
+  category = var.sumologic_category
+  fields   = var.sumologic_collector_fields
+}
+
+resource "sumologic_gcp_source" "this" {
+  name        = local.sumologic_source_name
+  description = var.sumologic_description
+
+  collector_id = sumologic_collector.this.id
+  category     = var.sumologic_category
+}

--- a/gcp/cloudlogging/variables.tf
+++ b/gcp/cloudlogging/variables.tf
@@ -1,0 +1,51 @@
+variable "gcp_project" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "logging_sink_filter" {
+  description = "Logging filter for the GCP sink."
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "Names that will be assigned to resources."
+  type        = string
+}
+
+variable "sumologic_category" {
+  description = "The category description for the collector/source."
+  type        = string
+  default     = "gcp"
+}
+
+variable "sumologic_collector_fields" {
+  description = "A Map containing key/value pairs."
+  type        = map(any)
+  default     = null
+}
+
+variable "sumologic_collector_name" {
+  description = "Name for the collector."
+  type        = string
+  default     = null
+}
+
+variable "sumologic_collector_timezone" {
+  description = "The time zone to use for this collector."
+  type        = string
+  default     = null
+}
+
+variable "sumologic_description" {
+  description = "The description of the created resources collector/source."
+  type        = string
+  default     = null
+}
+
+variable "sumologic_source_name" {
+  description = "Name for the GCP source."
+  type        = string
+  default     = null
+}

--- a/gcp/cloudlogging/versions.tf
+++ b/gcp/cloudlogging/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0"
+    }
+    sumologic = {
+      source  = "SumoLogic/sumologic"
+      version = ">= 2.11"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This PR introduces a module for sending project wide logs from Google Cloud Platform to Sumologic.

The code has been tested and is actively being used in both GCP and
SumoLogic.

I was not sure about two thngs:
- Where to put the examples. Normally they would
reside inside the module as a subfolder but I can move them to the main
"examples" folder.
- Do I need to push a change regarding a new release for this module.

Looking forward to collaborating with you!
Thank you!